### PR TITLE
Do not draw transparent polygons

### DIFF
--- a/staticmap/staticmap.py
+++ b/staticmap/staticmap.py
@@ -431,7 +431,8 @@ class StaticMap:
             if polygon.simplify:
                 points = _simplify(points)
 
-            draw.polygon(points, fill=polygon.fill_color, outline=polygon.outline_color)
+            if polygon.fill_color or polygon.outline_color:
+                draw.polygon(points, fill=polygon.fill_color, outline=polygon.outline_color)
 
         image_lines = image_lines.resize((self.width, self.height), Image.ANTIALIAS)
 


### PR DESCRIPTION
Do not draw polygons on the map if fill_color and outline_color are None.

``` python
m = StaticMap(500, 400)
m.add_marker(CircleMarker((7.15, 46.80), '#0036FF', 12))
bbox_coords = [
    [5.96, 47.81],
    [5.96, 45.83],
    [10.49, 45.83],
    [10.49, 47.81],
    [5.96, 47.81]]
m.add_polygon(Polygon(bbox_coords, None, None))
image = m.render()
image.save('map.png')
```

Creates a thin polygon even though fill_color = None and outline_color = None. See https://imgur.com/yr3nQSX
