### PR TITLE
Optional tile caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(
     name='staticmap',
     packages=['staticmap'],
-    version='0.5.4',
+    version='0.5.5',
     description='A small, python-based library for creating map images with lines and markers.',
     author='Christoph Lingg',
     author_email='christoph@komoot.de',


### PR DESCRIPTION
Uses CacheControl to cache tiles. This reduces the number of HTTP requests when re-rendering a map instance that has changed slightly.
Haven't added CacheControl as a dependency because it's entirely optional.