### PR TITLE
fix rendering by replacing Image.ANTIALIAS with Image.LANCZOS

### DIFF
--- a/staticmap/staticmap.py
+++ b/staticmap/staticmap.py
@@ -503,7 +503,7 @@ class StaticMap:
             if polygon.fill_color or polygon.outline_color:
                 draw.polygon(points, fill=polygon.fill_color, outline=polygon.outline_color)
 
-        image_lines = image_lines.resize((self.width, self.height), Image.ANTIALIAS)
+        image_lines = image_lines.resize((self.width, self.height), Image.LANCZOS)
 
         # merge lines with base image
         image.paste(image_lines, (0, 0), image_lines)


### PR DESCRIPTION
Hi,

The latest release of Pillow removed [some constants](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants), including `Image.ANTIALIAS`, which causes this error:  
```python
    image_lines = image_lines.resize((self.width, self.height), Image.ANTIALIAS)
                                                                ^^^^^^^^^^^^^^^
AttributeError: module 'PIL.Image' has no attribute 'ANTIALIAS'
```

As indicated in the documentation, I have replaced it with `Image.LANCZOS`.
The following snippet generates an image without errors:

```python
from staticmap import Line, StaticMap

m = StaticMap(300, 400, 10)
m.headers = {"User-Agent": "Mozilla 5.0"}
line = Line([(2.3, 48.9), (4.83, 45.75)], "red", 2)
m.add_line(line)
image = m.render()
image.save("map.png")
```

![map](https://github.com/komoot/staticmap/assets/3525167/dadf9c7b-47a2-442e-9b08-a2ab4ebf2afb)



