### PR TITLE
Add User-Agent header to solve 403 error from OpenStreetMap tile server

### DIFF
--- a/staticmap/staticmap.py
+++ b/staticmap/staticmap.py
@@ -179,7 +179,7 @@ def _simplify(points, tolerance=11):
 
 
 class StaticMap:
-    def __init__(self, width, height, padding_x=0, padding_y=0, url_template="https://a.tile.openstreetmap.org/{z}/{x}/{y}.png", tile_size=256, tile_request_timeout=None, headers=None, reverse_y=False, background_color="#fff",
+    def __init__(self, width, height, padding_x=0, padding_y=0, url_template="https://a.tile.openstreetmap.org/{z}/{x}/{y}.png", tile_size=256, tile_request_timeout=None, headers={"User-Agent": "StaticMap"}, reverse_y=False, background_color="#fff",
                  delay_between_retries=0):
         """
         :param width: map width in pixel


### PR DESCRIPTION
The original tile server was changed to OpenStreetMap(OSM) tile server in 6f5f9fc. However, it will cause 403 error if there is no `User-Agent` in header according to OSM's [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles).

I just add the `User-Agent` in header to solve this problem.

By the way, I think it's better to add the package's version in `User-Agent` (e.g. `StaticMap/0.5.5`), one simple way to get it is to use built-in `importlib.metadata.version` function. Yet this function only works above python 3.8, so I gave up using this approach and only used a plain string in `User-Agent` in this PR.
