### PR TITLE
fix: replace bare except to allow interrupting execution

### DIFF
--- a/staticmap/staticmap.py
+++ b/staticmap/staticmap.py
@@ -422,7 +422,7 @@ class StaticMap:
 
                 try:
                     response_status_code, response_content = future.result()
-                except:
+                except Exception:
                     response_status_code, response_content = None, None
 
                 if response_status_code != 200:


### PR DESCRIPTION
Hi,

This PR provides a fix on tile requests to handle interrupts (I use staticmap with asynchronous tasks that can be interrupted, the bare except prevents tasks from stopping properly).
